### PR TITLE
refactor(committer): enhance commit message generation with context

### DIFF
--- a/bin/committer
+++ b/bin/committer
@@ -37,48 +37,121 @@ def execute_git_diff_staged
     else
       begin
         client = Clients::ClaudeClient.new
+        
+        # Prompt user for commit context
+        puts 'Why are you making this change? (Press Enter to skip)'
+        commit_context = gets.chomp
+        
         puts 'Sending diff to Claude...'
 
-        prompt = <<~PROMPT
-          Below is a git diff of staged changes. Please analyze it and create a commit message following the Conventional Commits format:
+        # If user provided context, ask for body. Otherwise, just ask for summary.
+        if commit_context.empty?
+          prompt = <<~PROMPT
+            Below is a git diff of staged changes. Please analyze it and create a commit message following the Conventional Commits format with ONLY a summary line (NO body):
 
-          Format: <type>(<optional scope>): <description>
+            Format:#{' '}
+            <type>(<optional scope>): <description>
 
-          Types:
-          - feat: A new feature
-          - fix: A bug fix
-          - docs: Documentation only changes
-          - style: Changes that do not affect the meaning of the code
-          - refactor: A code change that neither fixes a bug nor adds a feature
-          - perf: A code change that improves performance
-          - test: Adding missing tests or correcting existing tests
-          - chore: Changes to the build process or auxiliary tools
+            Types:
+            - feat: A new feature
+            - fix: A bug fix
+            - docs: Documentation only changes
+            - style: Changes that do not affect the meaning of the code
+            - refactor: A code change that neither fixes a bug nor adds a feature
+            - perf: A code change that improves performance
+            - test: Adding missing tests or correcting existing tests
+            - chore: Changes to the build process or auxiliary tools
 
-          Guidelines:
-          - Keep the first line under 70 characters
-          - Use imperative, present tense (e.g., "add" not "added" or "adds")
-          - Do not end with a period
-          - Be concise but descriptive
+            Guidelines:
+            - Keep the summary under 70 characters
+            - Use imperative, present tense (e.g., "add" not "added" or "adds")
+            - Do not end the summary with a period
+            - Be concise but descriptive in the summary
+            
+            Git Diff:
+            ```
+            #{stdout}
+            ```
 
-          Git Diff:
-          ```
-          #{stdout}
-          ```
+            Respond ONLY with the commit message summary line, nothing else.
+          PROMPT
+        else
+          prompt = <<~PROMPT
+            Below is a git diff of staged changes. Please analyze it and create a commit message following the Conventional Commits format with a summary line and a detailed body:
 
-          Respond ONLY with the commit message text, nothing else.
-        PROMPT
+            Format:#{' '}
+            <type>(<optional scope>): <description>
+
+            <blank line>
+            <body with more detailed explanation>
+
+            Types:
+            - feat: A new feature
+            - fix: A bug fix
+            - docs: Documentation only changes
+            - style: Changes that do not affect the meaning of the code
+            - refactor: A code change that neither fixes a bug nor adds a feature
+            - perf: A code change that improves performance
+            - test: Adding missing tests or correcting existing tests
+            - chore: Changes to the build process or auxiliary tools
+
+            Guidelines:
+            - Keep the first line (summary) under 70 characters
+            - Use imperative, present tense (e.g., "add" not "added" or "adds")
+            - Do not end the summary with a period
+            - Be concise but descriptive in the summary
+            - Add a blank line between summary and body
+            - Use the body to explain why the change was made, incorporating the user's context
+            - Wrap each line in the body at 80 characters maximum
+            - Break the body into multiple paragraphs if needed
+            
+            User's context for this change: #{commit_context}
+
+            Git Diff:
+            ```
+            #{stdout}
+            ```
+
+            Respond ONLY with the commit message text (summary and body), nothing else.
+          PROMPT
+        end
 
         response = client.post(prompt)
-        commit_message = begin
+        commit_message_text = begin
           response.dig('content', 0, 'text')
         rescue StandardError
           response.inspect
         end
 
+        # If user didn't provide context, response should only be a summary line
+        if commit_context.empty?
+          summary = commit_message_text.strip
+          body = nil
+        else
+          # Split the response into summary and body
+          message_parts = commit_message_text.split("\n\n", 2)
+          summary = message_parts[0].strip
+          body = message_parts[1]&.strip
+
+          # Wrap body text at 80 characters
+          if body
+            wrapped_body = body.gsub(/(.{1,80})(\s+|$)/, "\\1\n").strip
+            body = wrapped_body
+          end
+        end
+
+        puts "\nGenerated commit message:"
+        puts "Summary: #{summary}"
+        puts "Body: #{body}" if body
+
         puts "\nOpening git commit with the suggested message..."
 
         # Create git commit with the suggested message and open in editor
-        system('git', 'commit', '-m', commit_message, '-e')
+        if body
+          system('git', 'commit', '-m', summary, '-m', body, '-e')
+        else
+          system('git', 'commit', '-m', summary, '-e')
+        end
       rescue Clients::ClaudeClient::ConfigError => e
         puts "Error: #{e.message}"
         exit 1


### PR DESCRIPTION
Allow user to provide context for the change when generating a commit message. The summary line is generated based on the git diff alone, while the body incorporates the user's provided context to explain the reason for the change. This makes commit messages more informative and easier to understand. If no context is provided, only a summary line is generated without a body. The generated message adheres to the Conventional Commits format, with guidelines
for keeping the summary concise, using imperative tense, and wrapping body text.