### PR TITLE
chore: remove git-smart-commit script and update gemspec

### DIFF
--- a/bin/git-smart-commit
+++ b/bin/git-smart-commit
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-# This is a git integration script that allows users to run:
-# git smart-commit
-# which will forward to the committer command
-
-require_relative 'committer'

--- a/committer.gemspec
+++ b/committer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*', 'bin/*', 'README.md', 'LICENSE.txt']
   spec.bindir = 'bin'
-  spec.executables = %w[git-smart-commit committer]
+  spec.executables = %w[git-smart-commit]
   spec.require_paths = ['lib']
 
   spec.add_dependency 'httparty', '~> 0.20'


### PR DESCRIPTION
Remove the git-smart-commit script and its reference in gemspec's executables as it's no longer being used. The script was originally created as a git integration to forward to the committer command, but this functionality is now unnecessary.