### PR TITLE
Refactor/committer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,6 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 20
+
+Style/Documentation:
+  Enabled: false

--- a/bin/committer
+++ b/bin/committer
@@ -2,12 +2,8 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'open3'
-require 'httparty'
-require 'yaml'
 require_relative '../lib/committer/config'
-require_relative '../lib/committer/prompt_templates'
-require_relative '../lib/clients/claude_client'
+require_relative '../lib/committer/commit_generator'
 
 # Handle command line arguments
 command = ARGV[0]
@@ -28,82 +24,14 @@ when 'help', '--help', '-h'
 end
 
 # Default behavior: generate commit message
-def build_commit_prompt(diff, commit_context = nil)
-  scopes = Committer::Config.load
-  scope_section = scopes.empty? ? '' : "\nScopes:\n#{scopes.map { |s| "- #{s}" }.join("\n")}"
-  scope_instruction = if scopes.empty?
-                        '- DO NOT include a scope in your commit message'
-                      else
-                        '- Choose an appropriate scope from the list above if relevant to the change'
-                      end
-  format(template(commit_context),
-         diff: diff,
-         scopes_section: scope_section,
-         scope_instruction: scope_instruction,
-         commit_context: commit_context)
-end
-
-def template(commit_context)
-  if commit_context.nil? || commit_context.empty?
-    Committer::PromptTemplates::SUMMARY_ONLY
-  else
-    Committer::PromptTemplates::SUMMARY_AND_BODY
-  end
-end
-
-def check_git_status
-  stdout, stderr, status = Open3.capture3('git diff --staged')
-
-  unless status.success?
-    puts 'Error executing git diff --staged:'
-    puts stderr
-    exit 1
-  end
-
-  if stdout.empty?
-    puts 'No changes are staged for commit.'
-    exit 0
-  end
-
-  stdout
-end
-
-def parse_response(response, commit_context)
-  text = response.dig('content', 0, 'text')
-
-  # If user didn't provide context, response should only be a summary line
-  if commit_context.nil? || commit_context.empty?
-    { summary: text.strip, body: nil }
-  else
-    # Split the response into summary and body
-    message_parts = text.split("\n\n", 2)
-    summary = message_parts[0].strip
-    body = message_parts[1]&.strip
-
-    # Wrap body text at 80 characters
-    body = body.gsub(/(.{1,80})(\s+|$)/, "\\1\n").strip if body
-
-    { summary: summary, body: body }
-  end
-end
-
-def prepare_commit_message(diff, commit_context = nil)
-  client = Clients::ClaudeClient.new
-  puts 'Sending diff to Claude...'
-
-  prompt = build_commit_prompt(diff, commit_context)
-  response = client.post(prompt)
-  parse_response(response, commit_context)
-end
-
 def execute_git_diff_staged
-  diff = check_git_status
+  diff = Committer::CommitGenerator.check_git_status
 
   # Prompt user for commit context
   puts 'Why are you making this change? (Press Enter to skip)'
   commit_context = gets.chomp
-
-  commit_message = prepare_commit_message(diff, commit_context)
+  commit_generator = Committer::CommitGenerator.new(diff, commit_context)
+  commit_message = commit_generator.prepare_commit_message
 
   summary = commit_message[:summary]
   body = commit_message[:body]

--- a/lib/committer/commit_generator.rb
+++ b/lib/committer/commit_generator.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'httparty'
+require 'yaml'
+require_relative 'config'
+require_relative 'prompt_templates'
+require_relative '../clients/claude_client'
+
+module Committer
+  class CommitGenerator
+    attr_reader :diff, :commit_context
+
+    def initialize(diff, commit_context = nil)
+      @diff = diff
+      @commit_context = commit_context
+    end
+
+    def build_commit_prompt
+      scopes = Committer::Config.load
+      scope_section = scopes.empty? ? '' : "\nScopes:\n#{scopes.map { |s| "- #{s}" }.join("\n")}"
+      scope_instruction = if scopes.empty?
+                            '- DO NOT include a scope in your commit message'
+                          else
+                            '- Choose an appropriate scope from the list above if relevant to the change'
+                          end
+      format(template,
+             diff: @diff,
+             scopes_section: scope_section,
+             scope_instruction: scope_instruction,
+             commit_context: @commit_context)
+    end
+
+    def template
+      if @commit_context.nil? || @commit_context.empty?
+        Committer::PromptTemplates::SUMMARY_ONLY
+      else
+        Committer::PromptTemplates::SUMMARY_AND_BODY
+      end
+    end
+
+    def self.check_git_status
+      stdout, stderr, status = Open3.capture3('git diff --staged')
+
+      unless status.success?
+        puts 'Error executing git diff --staged:'
+        puts stderr
+        exit 1
+      end
+
+      if stdout.empty?
+        puts 'No changes are staged for commit.'
+        exit 0
+      end
+
+      stdout
+    end
+
+    def parse_response(response)
+      text = response.dig('content', 0, 'text')
+
+      # If user didn't provide context, response should only be a summary line
+      if @commit_context.nil? || @commit_context.empty?
+        { summary: text.strip, body: nil }
+      else
+        # Split the response into summary and body
+        message_parts = text.split("\n\n", 2)
+        summary = message_parts[0].strip
+        body = message_parts[1]&.strip
+
+        # Wrap body text at 80 characters
+        body = body.gsub(/(.{1,80})(\s+|$)/, "\\1\n").strip if body
+
+        { summary: summary, body: body }
+      end
+    end
+
+    def prepare_commit_message
+      client = Clients::ClaudeClient.new
+      puts 'Sending diff to Claude...'
+
+      prompt = build_commit_prompt
+      response = client.post(prompt)
+      parse_response(response)
+    end
+  end
+end


### PR DESCRIPTION
Create a dedicated CommitGenerator class to isolate business logic from the
command-line interface. This refactoring moves all the commit message
generation functionality into a separate class, making the code more
maintainable and testable. The generator handles preparing the prompt,
communicating with Claude, and formatting the response, while the command
script remains focused on user interaction and execution flow.