### PR TITLE
feat: add output-message subcommand to support git hooks

### DIFF
--- a/bin/committer
+++ b/bin/committer
@@ -21,6 +21,22 @@ when 'help', '--help', '-h'
   puts '  committer        - Generate commit message for staged changes'
   puts
   exit 0
+when 'output-message'
+  commit_context = ARGV[1]
+  diff = Committer::CommitGenerator.check_git_status
+
+  commit_generator = Committer::CommitGenerator.new(diff, commit_context)
+  commit_message = commit_generator.prepare_commit_message
+
+  summary = commit_message[:summary]
+  body = commit_message[:body]
+
+  puts <<~OUTPUT
+    #{summary}
+
+    #{body}
+  OUTPUT
+  exit 0
 end
 
 # Default behavior: generate commit message

--- a/lib/committer/commit_generator.rb
+++ b/lib/committer/commit_generator.rb
@@ -77,7 +77,6 @@ module Committer
 
     def prepare_commit_message
       client = Clients::ClaudeClient.new
-      puts 'Sending diff to Claude...'
 
       prompt = build_commit_prompt
       response = client.post(prompt)


### PR DESCRIPTION
Adds a new 'output-message' subcommand to the committer CLI that prints the generated commit message directly to stdout without interactive prompts. This allows the tool to be used as part of a git pre-commit-msg hook, enabling automated commit message generation in CI/CD pipelines or local git workflows. Also removes the progress message in prepare_commit_message to keep the output clean.