### PR TITLE
refactor: restructure command execution into separate files

### DIFF
--- a/bin/committer
+++ b/bin/committer
@@ -4,64 +4,10 @@
 require 'bundler/setup'
 require_relative '../lib/committer/config'
 require_relative '../lib/committer/commit_generator'
+require_relative '../lib/committer/commands'
 
 # Handle command line arguments
 command = ARGV[0]
+args = ARGV[1..]
 
-case command
-when 'setup'
-  Committer::Config.setup
-  exit 0
-
-when 'help', '--help', '-h'
-  puts 'Committer - AI-powered git commit message generator'
-  puts
-  puts 'Commands:'
-  puts '  committer setup  - Create the config file template at ~/.committer/config.yml'
-  puts '  committer        - Generate commit message for staged changes'
-  puts
-  exit 0
-when 'output-message'
-  commit_context = ARGV[1]
-  diff = Committer::CommitGenerator.check_git_status
-
-  commit_generator = Committer::CommitGenerator.new(diff, commit_context)
-  commit_message = commit_generator.prepare_commit_message
-
-  summary = commit_message[:summary]
-  body = commit_message[:body]
-
-  puts <<~OUTPUT
-    #{summary}
-
-    #{body}
-  OUTPUT
-  exit 0
-end
-
-# Default behavior: generate commit message
-def execute_git_diff_staged
-  diff = Committer::CommitGenerator.check_git_status
-
-  # Prompt user for commit context
-  puts 'Why are you making this change? (Press Enter to skip)'
-  commit_context = gets.chomp
-  commit_generator = Committer::CommitGenerator.new(diff, commit_context)
-  commit_message = commit_generator.prepare_commit_message
-
-  summary = commit_message[:summary]
-  body = commit_message[:body]
-
-  # Create git commit with the suggested message and open in editor
-  if body
-    system('git', 'commit', '-m', summary, '-m', body, '-e')
-  else
-    system('git', 'commit', '-m', summary, '-e')
-  end
-rescue Clients::ClaudeClient::ConfigError, StandardError => e
-  puts "Error: #{e.message}"
-  exit 1
-end
-
-# Execute the function if no specific command was given
-execute_git_diff_staged
+Committer::Commands.run(command, args)

--- a/lib/committer/commands.rb
+++ b/lib/committer/commands.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'commands/setup'
+require_relative 'commands/help'
+require_relative 'commands/output_message'
+require_relative 'commands/default'
+
+module Committer
+  module Commands
+    def self.run(command, args)
+      case command
+      when 'setup'
+        Setup.execute(args)
+      when 'help', '--help', '-h'
+        Help.execute(args)
+      when 'output-message'
+        OutputMessage.execute(args)
+      else
+        Default.execute(args)
+      end
+    end
+  end
+end

--- a/lib/committer/commands/default.rb
+++ b/lib/committer/commands/default.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Committer
+  module Commands
+    class Default
+      def self.execute_commit(diff, commit_context)
+        commit_generator = Committer::CommitGenerator.new(diff, commit_context)
+        commit_message = commit_generator.prepare_commit_message
+
+        summary = commit_message[:summary]
+        body = commit_message[:body]
+        # Create git commit with the suggested message and open in editor
+        if body
+          system('git', 'commit', '-m', summary, '-m', body, '-e')
+        else
+          system('git', 'commit', '-m', summary, '-e')
+        end
+      end
+
+      def self.execute(_args)
+        diff = Committer::CommitGenerator.check_git_status
+
+        if diff.empty?
+          puts 'No changes are staged for commit.'
+          exit 0
+        end
+
+        # Prompt user for commit context
+        puts 'Why are you making this change? (Press Enter to skip)'
+        commit_context = gets.chomp
+        execute_commit(diff, commit_context)
+      rescue Clients::ClaudeClient::ConfigError, StandardError => e
+        puts "Error: #{e.message}"
+        exit 1
+      end
+    end
+  end
+end

--- a/lib/committer/commands/help.rb
+++ b/lib/committer/commands/help.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Committer
+  module Commands
+    class Help
+      def self.execute(_args)
+        puts 'Committer - AI-powered git commit message generator'
+        puts
+        puts 'Commands:'
+        puts '  committer setup         - Create the config file template at ~/.committer/config.yml'
+        puts '  committer               - Generate commit message for staged changes'
+        puts '  committer output-message - Generate commit message without creating a commit'
+        puts
+        exit 0
+      end
+    end
+  end
+end

--- a/lib/committer/commands/output_message.rb
+++ b/lib/committer/commands/output_message.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Committer
+  module Commands
+    class OutputMessage
+      def self.execute(args)
+        commit_context = args[0]
+        diff = Committer::CommitGenerator.check_git_status
+
+        commit_generator = Committer::CommitGenerator.new(diff, commit_context)
+        commit_message = commit_generator.prepare_commit_message
+
+        summary = commit_message[:summary]
+        body = commit_message[:body]
+
+        puts <<~OUTPUT
+          #{summary}
+
+          #{body}
+        OUTPUT
+        exit 0
+      rescue Clients::ClaudeClient::ConfigError => e
+        puts "Error: #{e.message}"
+        exit 1
+      rescue StandardError
+        exit 0
+      end
+    end
+  end
+end

--- a/lib/committer/commands/setup.rb
+++ b/lib/committer/commands/setup.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Committer
+  module Commands
+    class Setup
+      def self.execute(_args)
+        Committer::Config.setup
+        exit 0
+      end
+    end
+  end
+end

--- a/lib/committer/commit_generator.rb
+++ b/lib/committer/commit_generator.rb
@@ -48,11 +48,6 @@ module Committer
         exit 1
       end
 
-      if stdout.empty?
-        puts 'No changes are staged for commit.'
-        exit 0
-      end
-
       stdout
     end
 

--- a/spec/committer/commands/default_spec.rb
+++ b/spec/committer/commands/default_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'committer/commands/default'
+
+RSpec.describe Committer::Commands::Default do
+  let(:diff) { 'sample diff content' }
+  let(:commit_context) { 'Test commit context' }
+  let(:commit_message) { { summary: 'feat: add new feature', body: 'This is the commit body' } }
+  let(:commit_generator) { instance_double(Committer::CommitGenerator) }
+
+  describe '.execute' do
+    before do
+      allow(Committer::CommitGenerator).to receive(:check_git_status).and_return(diff)
+      allow(described_class).to receive(:puts)
+      allow(described_class).to receive(:gets).and_return(commit_context)
+      allow(described_class).to receive(:execute_commit)
+      allow(described_class).to receive(:exit)
+    end
+
+    context 'when there are staged changes' do
+      it 'prompts for commit context and executes commit' do
+        expect(described_class).to receive(:puts).with('Why are you making this change? (Press Enter to skip)')
+        expect(described_class).to receive(:execute_commit).with(diff, commit_context)
+
+        described_class.execute([])
+      end
+    end
+
+    context 'when there are no staged changes' do
+      let(:diff) { '' }
+
+      it 'shows a message and exits' do
+        expect(described_class).to receive(:puts).with('No changes are staged for commit.')
+        expect(described_class).to receive(:exit).with(0)
+
+        described_class.execute([])
+      end
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(Committer::CommitGenerator).to receive(:check_git_status).and_raise(StandardError.new('Test error'))
+      end
+
+      it 'shows the error message and exits' do
+        expect(described_class).to receive(:puts).with('Error: Test error')
+        expect(described_class).to receive(:exit).with(1)
+
+        described_class.execute([])
+      end
+
+      it 'handles ConfigError' do
+        expected_error = Clients::ClaudeClient::ConfigError.new('Config error')
+        allow(Committer::CommitGenerator).to receive(:check_git_status).and_raise(expected_error)
+        expect(described_class).to receive(:puts).with('Error: Config error')
+        expect(described_class).to receive(:exit).with(1)
+
+        described_class.execute([])
+      end
+    end
+  end
+
+  describe '.execute_commit' do
+    before do
+      allow(Committer::CommitGenerator).to receive(:new).with(diff, commit_context).and_return(commit_generator)
+      allow(commit_generator).to receive(:prepare_commit_message).and_return(commit_message)
+      allow(described_class).to receive(:system)
+    end
+
+    context 'when commit includes a body' do
+      it 'creates a commit with summary and body' do
+        expect(described_class).to receive(:system).with('git', 'commit', '-m', commit_message[:summary], '-m',
+                                                         commit_message[:body], '-e')
+
+        described_class.execute_commit(diff, commit_context)
+      end
+    end
+
+    context 'when commit has no body' do
+      let(:commit_message) { { summary: 'feat: add new feature', body: nil } }
+
+      it 'creates a commit with only the summary' do
+        expect(described_class).to receive(:system).with('git', 'commit', '-m', commit_message[:summary], '-e')
+
+        described_class.execute_commit(diff, commit_context)
+      end
+    end
+  end
+end

--- a/spec/committer/commands/output_message_spec.rb
+++ b/spec/committer/commands/output_message_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'committer/commands/output_message'
+
+RSpec.describe Committer::Commands::OutputMessage do
+  let(:diff) { 'sample diff content' }
+  let(:commit_context) { 'Test commit context' }
+  let(:commit_message) { { summary: 'feat: add new feature', body: 'This is the commit body' } }
+  let(:commit_generator) { instance_double(Committer::CommitGenerator) }
+
+  describe '.execute' do
+    before do
+      allow(Committer::CommitGenerator).to receive(:check_git_status).and_return(diff)
+      allow(Committer::CommitGenerator).to receive(:new).with(diff, commit_context).and_return(commit_generator)
+      allow(commit_generator).to receive(:prepare_commit_message).and_return(commit_message)
+      allow(described_class).to receive(:puts)
+      allow(described_class).to receive(:exit)
+    end
+
+    it 'outputs the commit message summary and body' do
+      expected_output = <<~OUTPUT
+        #{commit_message[:summary]}
+
+        #{commit_message[:body]}
+      OUTPUT
+
+      expect(described_class).to receive(:puts).with(expected_output)
+      expect(described_class).to receive(:exit).with(0)
+
+      described_class.execute([commit_context])
+    end
+
+    context 'when there is no body' do
+      let(:commit_message) { { summary: 'feat: add new feature', body: nil } }
+
+      it 'outputs only the summary' do
+        expected_output = <<~OUTPUT
+          #{commit_message[:summary]}
+
+
+        OUTPUT
+
+        expect(described_class).to receive(:puts).with(expected_output)
+        expect(described_class).to receive(:exit).with(0)
+
+        described_class.execute([commit_context])
+      end
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(Committer::CommitGenerator).to receive(:check_git_status).and_raise(StandardError.new('Test error'))
+      end
+
+      it 'shows the error message and exits' do
+        expect(described_class).to receive(:exit).with(0)
+
+        described_class.execute([commit_context])
+      end
+
+      it 'handles ConfigError' do
+        expected_error = Clients::ClaudeClient::ConfigError.new('Config error')
+        allow(Committer::CommitGenerator).to receive(:check_git_status).and_raise(expected_error)
+        expect(described_class).to receive(:puts).with('Error: Config error')
+        expect(described_class).to receive(:exit).with(1)
+
+        described_class.execute([commit_context])
+      end
+    end
+  end
+end

--- a/spec/committer/commit_generator_spec.rb
+++ b/spec/committer/commit_generator_spec.rb
@@ -125,9 +125,7 @@ RSpec.describe Committer::CommitGenerator do
       end
 
       it 'outputs message and exits' do
-        expect(described_class).to receive(:puts).with('No changes are staged for commit.')
-        expect(described_class).to receive(:exit).with(0)
-        described_class.check_git_status
+        expect(described_class.check_git_status).to eq('')
       end
     end
   end


### PR DESCRIPTION
Move all commands to separate files for better organization and maintainability. This refactoring isolates each command's functionality into its own class, making it easier to develop and test individual components. The main CommitGenerator now returns empty diff output instead of exiting, making it compatible with non-interactive usage and preventing premature program termination when checking git status.