### PR TITLE
feat: add git hook integration for automatic commit message generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,41 @@ This will:
 - `committer` - Generate commit message for staged changes
 - `committer setup` - Create the config file template
 - `committer help` - Display help information
+- `committer setup-git-hook` - Install the git hook for automatic commit message generation
+- `committer output-message` - Generate a commit message (used by the git hook)
+
+## Git Hook Integration
+
+Committer can be integrated directly with Git using a prepare-commit-msg hook, which automatically generates commit messages whenever you commit.
+
+### Installing the Git Hook
+
+To install the git hook, navigate to the root of your git repository and run:
+
+```bash
+committer setup-git-hook
+```
+
+This command will:
+1. Verify you're in the root of a git repository
+2. Install the prepare-commit-msg hook in your `.git/hooks` directory
+3. Make the hook executable
+
+### How the Git Hook Works
+
+Once installed, the git hook will:
+1. Automatically run whenever you execute `git commit`
+2. Generate an AI-powered commit message based on your staged changes
+3. Pre-fill your commit message editor with the generated message
+4. Allow you to edit the message before finalizing the commit
+
+Since git hooks run in non-interactive mode, you can provide context for your commit by using the REASON environment variable:
+
+```bash
+REASON="Improve performance by optimizing database queries" git commit
+```
+
+If you don't provide a REASON, the commit message will still be generated, but without the additional context that would be used to generate a more detailed body.
 
 ## Development
 

--- a/lib/committer/commands.rb
+++ b/lib/committer/commands.rb
@@ -3,6 +3,7 @@
 require_relative 'commands/setup'
 require_relative 'commands/help'
 require_relative 'commands/output_message'
+require_relative 'commands/setup_git_hook'
 require_relative 'commands/default'
 
 module Committer
@@ -15,6 +16,8 @@ module Committer
         Help.execute(args)
       when 'output-message'
         OutputMessage.execute(args)
+      when 'setup-git-hook'
+        SetupGitHook.execute(args)
       else
         Default.execute(args)
       end

--- a/lib/committer/commands/help.rb
+++ b/lib/committer/commands/help.rb
@@ -7,9 +7,10 @@ module Committer
         puts 'Committer - AI-powered git commit message generator'
         puts
         puts 'Commands:'
-        puts '  committer setup         - Create the config file template at ~/.committer/config.yml'
-        puts '  committer               - Generate commit message for staged changes'
+        puts '  committer setup          - Create the config file template at ~/.committer/config.yml'
+        puts '  committer                - Generate commit message for staged changes'
         puts '  committer output-message - Generate commit message without creating a commit'
+        puts '  committer setup-git-hook - Install the prepare-commit-msg git hook'
         puts
         exit 0
       end

--- a/lib/committer/commands/setup_git_hook.rb
+++ b/lib/committer/commands/setup_git_hook.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Committer
+  module Commands
+    class SetupGitHook
+      HOOK_PATH = '.git/hooks/prepare-commit-msg'
+
+      def self.execute(_args)
+        validate_git_repository
+        install_git_hook
+        display_success_message
+        exit 0
+      rescue StandardError => e
+        puts "Error: #{e.message}"
+        exit 1
+      end
+
+      def self.validate_git_repository
+        validate_git_root
+        validate_git_directory_exists
+        validate_hook_doesnt_exist
+      end
+
+      def self.validate_git_directory_exists
+        return if Dir.exist?('.git')
+
+        puts 'Error: Current directory is not a git repository.'
+        exit 1
+      end
+
+      def self.validate_git_root
+        git_toplevel = `git rev-parse --show-toplevel`.strip
+        current_dir = Dir.pwd
+        return if git_toplevel == current_dir
+
+        puts 'Error: Please run this command from the root of your git repository.'
+        exit 1
+      end
+
+      def self.validate_hook_doesnt_exist
+        return unless File.exist?(HOOK_PATH)
+
+        puts 'Error: prepare-commit-msg hook already exists.'
+        puts 'Please remove or rename the existing hook and try again.'
+        exit 1
+      end
+
+      def self.install_git_hook
+        template_path = File.expand_path('../prepare-commit-msg', __dir__)
+        hook_content = File.read(template_path)
+        File.write(HOOK_PATH, hook_content)
+        File.chmod(0o755, HOOK_PATH)
+      end
+
+      def self.display_success_message
+        puts 'Git hook successfully installed!'
+        puts 'Now your commit messages will be automatically generated.'
+      end
+    end
+  end
+end

--- a/lib/committer/prepare-commit-msg
+++ b/lib/committer/prepare-commit-msg
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Check if parameters 2 and 3 are null
+if [ -z "$2" ] && [ -z "$3" ]; then
+    # Check if parameter 1 is provided and is a valid file
+    if [ -z "$1" ]; then
+        echo "Error: No target file specified in parameter 1"
+        exit 1
+    fi
+    
+    if [ ! -f "$1" ]; then
+        echo "Error: File '$1' does not exist"
+        exit 1
+    fi
+    
+    # Check if committer command exists
+    if command -v committer &> /dev/null; then
+        # Execute committer command and capture its output
+        COMMITTER_OUTPUT=$(committer output-message "$REASON")
+        
+        # Create a temporary file with the committer output at the top
+        # followed by the original content of the file
+        {
+            echo "$COMMITTER_OUTPUT"
+            cat "$1"
+        } > "$1.tmp"
+        
+        # Replace the original file with the temporary file
+        mv "$1.tmp" "$1"
+        
+        echo "Successfully added committer output to the top of $1"
+    else
+        echo "Committer command not found - no action taken"
+    fi
+fi

--- a/spec/committer/commands/setup_git_hook_spec.rb
+++ b/spec/committer/commands/setup_git_hook_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'committer/commands/setup_git_hook'
+
+RSpec.describe Committer::Commands::SetupGitHook do
+  describe '.execute' do
+    context 'when not in a git repository' do
+      before do
+        allow(Dir).to receive(:exist?).with('.git').and_return(false)
+        allow($stdout).to receive(:puts)
+      end
+
+      it 'exits with status code 1' do
+        expect { described_class.execute([]) }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+
+      it 'outputs an error message' do
+        expect($stdout).to receive(:puts).with('Error: Current directory is not a git repository.')
+
+        begin
+          described_class.execute([])
+        rescue SystemExit
+          # Expected
+        end
+      end
+    end
+
+    context 'when not at the root of a git repository' do
+      before do
+        allow(Dir).to receive(:exist?).with('.git').and_return(true)
+        allow(described_class).to receive(:`).with('git rev-parse --show-toplevel').and_return("/different/path\n")
+        allow(Dir).to receive(:pwd).and_return('/current/path')
+        allow($stdout).to receive(:puts)
+      end
+
+      it 'exits with status code 1' do
+        expect { described_class.execute([]) }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+
+      it 'outputs an error message' do
+        expect($stdout).to receive(:puts).with('Error: Please run this command from the root of your git repository.')
+
+        begin
+          described_class.execute([])
+        rescue SystemExit
+          # Expected
+        end
+      end
+    end
+
+    context 'when hook file already exists' do
+      before do
+        allow(Dir).to receive(:exist?).with('.git').and_return(true)
+        allow(described_class).to receive(:`).with('git rev-parse --show-toplevel').and_return("#{Dir.pwd}\n")
+        allow(Dir).to receive(:pwd).and_return(Dir.pwd)
+        allow(File).to receive(:exist?).with('.git/hooks/prepare-commit-msg').and_return(true)
+        allow($stdout).to receive(:puts)
+      end
+
+      it 'exits with status code 1' do
+        expect { described_class.execute([]) }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+
+      it 'outputs an error message' do
+        expect($stdout).to receive(:puts).with('Error: prepare-commit-msg hook already exists.')
+        expect($stdout).to receive(:puts).with('Please remove or rename the existing hook and try again.')
+
+        begin
+          described_class.execute([])
+        rescue SystemExit
+          # Expected
+        end
+      end
+    end
+
+    context 'when installation succeeds' do
+      let(:hook_path) { '.git/hooks/prepare-commit-msg' }
+      let(:template_path) { File.expand_path('../prepare-commit-msg', File.dirname(__dir__)) }
+      let(:hook_content) { '#!/bin/sh\n# Test hook content' }
+
+      before do
+        allow(Dir).to receive(:exist?).with('.git').and_return(true)
+        allow(described_class).to receive(:`).with('git rev-parse --show-toplevel').and_return("#{Dir.pwd}\n")
+        allow(Dir).to receive(:pwd).and_return(Dir.pwd)
+        allow(File).to receive(:exist?).with(hook_path).and_return(false)
+        allow(File).to receive(:expand_path).with('../prepare-commit-msg', anything).and_return(template_path)
+        allow(File).to receive(:read).with(template_path).and_return(hook_content)
+        allow(File).to receive(:write)
+        allow(File).to receive(:chmod)
+        allow($stdout).to receive(:puts)
+      end
+
+      it 'reads the hook template file' do
+        expect(File).to receive(:read).with(template_path).and_return(hook_content)
+
+        begin
+          described_class.execute([])
+        rescue SystemExit
+          # Expected
+        end
+      end
+
+      it 'writes the hook file with the template content' do
+        expect(File).to receive(:write).with(hook_path, hook_content)
+
+        begin
+          described_class.execute([])
+        rescue SystemExit
+          # Expected
+        end
+      end
+
+      it 'makes the hook file executable' do
+        expect(File).to receive(:chmod).with(0o755, hook_path)
+
+        begin
+          described_class.execute([])
+        rescue SystemExit
+          # Expected
+        end
+      end
+
+      it 'outputs success message' do
+        expect($stdout).to receive(:puts).with('Git hook successfully installed!')
+        expect($stdout).to receive(:puts).with('Now your commit messages will be automatically generated.')
+
+        begin
+          described_class.execute([])
+        rescue SystemExit
+          # Expected
+        end
+      end
+
+      it 'exits with status code 0' do
+        expect { described_class.execute([]) }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(0)
+        end
+      end
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(Dir).to receive(:exist?).with('.git').and_return(true)
+        allow(described_class).to receive(:`).with('git rev-parse --show-toplevel').and_return("#{Dir.pwd}\n")
+        allow(Dir).to receive(:pwd).and_return(Dir.pwd)
+        allow(File).to receive(:exist?).with('.git/hooks/prepare-commit-msg').and_return(false)
+        allow(File).to receive(:expand_path).with('../prepare-commit-msg', anything).and_return('/path/to/template')
+        allow(File).to receive(:read).and_raise(StandardError.new('Test error'))
+        allow($stdout).to receive(:puts)
+      end
+
+      it 'exits with status code 1' do
+        expect { described_class.execute([]) }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end
+
+      it 'outputs an error message' do
+        expect($stdout).to receive(:puts).with('Error: Test error')
+
+        begin
+          described_class.execute([])
+        rescue SystemExit
+          # Expected
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This feature adds a git hook integration to allow users to use git commit with automatic message generation. The implementation includes:
- Add `setup-git-hook` command to install a prepare-commit-msg hook
- Create a prepare-commit-msg hook template that runs committer
- Update documentation with installation and usage instructions
- Add tests for the new setup-git-hook command and related functionality The hook pre-fills commit messages while allowing users to edit them before finalizing. Users can provide additional context via the REASON environment variable when making commits.