### PR TITLE
chore: Add Pry gem for improved debugging in test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :development, :test do
   gem 'rspec', '~> 3.12'
   gem 'rubocop', '~> 1.73.2'
   gem 'webmock', '~> 3.18'
+  gem 'pry', '~> 0.15.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     bigdecimal (3.1.9)
+    coderay (1.1.3)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -18,6 +19,7 @@ GEM
     json (2.10.1)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
@@ -25,6 +27,9 @@ GEM
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (6.0.1)
     racc (1.8.1)
     rainbow (3.1.1)
@@ -73,6 +78,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.2)
   httparty (~> 0.20)
+  pry (~> 0.15.0)
   rake (~> 13.0)
   rspec (~> 3.12)
   rubocop (~> 1.73.2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'webmock/rspec'
+require 'pry'
 
 # Add the lib directory to the load path
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)


### PR DESCRIPTION
Adds the Pry interactive debugger to development and test environments to help with debugging tests. Pry provides a more powerful alternative to Ruby's standard debugger with features like syntax highlighting, runtime invocation, and better inspection capabilities. The change includes updates to Gemfile, Gemfile.lock, and requiring Pry in the spec_helper.