### PR TITLE
fix: Fix scopes handling in CommitGenerator

### DIFF
--- a/lib/committer/commit_generator.rb
+++ b/lib/committer/commit_generator.rb
@@ -17,7 +17,7 @@ module Committer
     end
 
     def build_commit_prompt
-      scopes = Committer::Config.load
+      scopes = Committer::Config.load[:scopes] || []
       scope_section = scopes.empty? ? '' : "\nScopes:\n#{scopes.map { |s| "- #{s}" }.join("\n")}"
       scope_instruction = if scopes.empty?
                             '- DO NOT include a scope in your commit message'

--- a/spec/committer/commit_generator_spec.rb
+++ b/spec/committer/commit_generator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Committer::CommitGenerator do
   describe '#build_commit_prompt' do
     context 'when no scopes are configured' do
       before do
-        allow(Committer::Config).to receive(:load).and_return([])
+        allow(Committer::Config).to receive(:load).and_return({})
       end
 
       it 'builds prompt with no scopes' do
@@ -33,7 +33,7 @@ RSpec.describe Committer::CommitGenerator do
       let(:scopes) { %w[api ui docs] }
 
       before do
-        allow(Committer::Config).to receive(:load).and_return(scopes)
+        allow(Committer::Config).to receive(:load).and_return(scopes: scopes)
       end
 
       it 'builds prompt with scopes' do
@@ -52,7 +52,7 @@ RSpec.describe Committer::CommitGenerator do
       let(:generator) { described_class.new(diff, commit_context) }
 
       before do
-        allow(Committer::Config).to receive(:load).and_return([])
+        allow(Committer::Config).to receive(:load).and_return({})
       end
 
       it 'uses the template with body' do


### PR DESCRIPTION
Modify CommitGenerator to correctly access scopes from the configuration hash rather than treating the entire configuration as the scopes array. This resolves an issue where tests were returning the wrong type in the Config.load method, causing failures in the test suite. The fix ensures proper extraction of the scopes array from the configuration hash, with a fallback to an empty array when scopes are not defined.