### PR TITLE
Refactor config

### DIFF
--- a/lib/clients/claude_client.rb
+++ b/lib/clients/claude_client.rb
@@ -12,7 +12,7 @@ module Clients
     class ConfigError < StandardError; end
 
     def initialize
-      @config = Committer::Config.load
+      @config = Committer::Config.instance
 
       return unless @config['api_key'].nil? || @config['api_key'].empty?
 

--- a/lib/committer/committer_errors.rb
+++ b/lib/committer/committer_errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Committer
+  # Configuration management for the Committer gem
+  class ConfigErrors
+    class BaseError < StandardError; end
+
+    # Request Processing Errors
+    class FormatError < BaseError; end
+    class NotSetup < BaseError; end
+  end
+end

--- a/lib/committer/config.rb
+++ b/lib/committer/config.rb
@@ -2,10 +2,14 @@
 
 require 'yaml'
 require 'fileutils'
+require 'singleton'
+require_relative 'committer_errors'
 
 module Committer
   # Configuration management for the Committer gem
   class Config
+    include Singleton
+
     CONFIG_DIR = File.join(Dir.home, '.committer')
     CONFIG_FILE = File.join(CONFIG_DIR, 'config.yml')
     DEFAULT_CONFIG = {
@@ -14,20 +18,18 @@ module Committer
       'scopes' => nil
     }.freeze
 
-    def self.load
-      create_default_config unless File.exist?(CONFIG_FILE)
-      begin
-        YAML.load_file(CONFIG_FILE) || DEFAULT_CONFIG
-      rescue StandardError => e
-        # Use $stdout directly for better test capture
-        $stdout.puts "Error loading config: #{e.message}"
-        DEFAULT_CONFIG
-      end
+    def initialize
+      @config = load_config
     end
 
-    def self.create_default_config
-      FileUtils.mkdir_p(CONFIG_DIR)
-      File.write(CONFIG_FILE, DEFAULT_CONFIG.to_yaml)
+    # Accessor for the loaded config
+    def [](key)
+      @config[key.to_sym] || @config[key.to_s]
+    end
+
+    # Get the entire config hash
+    def to_h
+      @config.dup
     end
 
     def self.setup
@@ -43,6 +45,50 @@ module Committer
       puts '  - feature'
       puts '  - api'
       puts '  - ui'
+    end
+
+    def self.create_default_config
+      FileUtils.mkdir_p(CONFIG_DIR)
+      File.write(CONFIG_FILE, DEFAULT_CONFIG.to_yaml)
+    end
+
+    def load_config
+      # Load configs from both locations and merge them
+      home_config = load_config_from_path(CONFIG_FILE)
+      git_root_config = load_config_from_git_root
+      raise Committer::ConfigErrors::NotSetup if home_config.empty? && git_root_config.empty?
+
+      # Merge configs with git root taking precedence
+      home_config.merge(git_root_config)
+    end
+
+    def load_config_from_path(path)
+      return {} unless File.exist?(path)
+
+      result = YAML.load_file(path)
+      raise Committer::ConfigErrors::FormatError, 'Config file must be a YAML hash' unless result.is_a?(Hash)
+
+      result
+    end
+
+    def load_config_from_git_root
+      git_root = `git rev-parse --show-toplevel`.strip
+      return {} if git_root.empty?
+
+      git_config_file = File.join(git_root, '.committer', 'config.yml')
+      load_config_from_path(git_config_file)
+    rescue StandardError
+      {}
+    end
+
+    # Force reload configuration (useful for testing)
+    def reload
+      @config = load_config
+    end
+
+    # Class method for reload
+    def self.reload
+      instance.reload
     end
   end
 end

--- a/lib/committer/prompt_templates.rb
+++ b/lib/committer/prompt_templates.rb
@@ -9,7 +9,7 @@ module Committer
     end
 
     def self.load_scopes
-      scopes = Committer::Config.load[:scopes] || []
+      scopes = Committer::Config.instance[:scopes] || []
       return 'DO NOT include a scope in your commit message' if scopes.empty?
 
       scope_list = "\nScopes:\n#{scopes.map { |s| "- #{s}" }.join("\n")}"

--- a/spec/clients/claude_client_spec.rb
+++ b/spec/clients/claude_client_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Clients::ClaudeClient do
 
   before do
     # Create and stub the Config singleton instance
+    allow_any_instance_of(Committer::Config).to receive(:load_config).and_return(config)
     allow_any_instance_of(Committer::Config).to receive(:to_h).and_return(config)
     allow_any_instance_of(Committer::Config).to receive(:[]) { |_, key| config[key] }
 

--- a/spec/clients/claude_client_spec.rb
+++ b/spec/clients/claude_client_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe Clients::ClaudeClient do
   let(:error_response) { { 'type' => 'error', 'error' => { 'type' => 'overloaded_error' } } }
 
   before do
-    allow(Committer::Config).to receive(:load).and_return(config)
+    # Create and stub the Config singleton instance
+    allow_any_instance_of(Committer::Config).to receive(:to_h).and_return(config)
+    allow_any_instance_of(Committer::Config).to receive(:[]) { |_, key| config[key] }
+
     # Stub WebMock to allow specific requests
     WebMock.disable_net_connect!
+
+    # Reset the singleton before each test
+    Singleton.__init__(Committer::Config)
   end
 
   describe '#initialize' do

--- a/spec/committer/commit_generator_spec.rb
+++ b/spec/committer/commit_generator_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Committer::CommitGenerator do
   describe '#build_commit_prompt' do
     context 'when no scopes are configured' do
       before do
-        allow(Committer::Config).to receive(:load).and_return({})
+        config_instance = instance_double(Committer::Config)
+        allow(config_instance).to receive(:[]).with('scopes').and_return(nil)
+        allow(Committer::Config).to receive(:instance).and_return(config_instance)
       end
 
       it 'builds prompt with no scopes' do
@@ -33,7 +35,9 @@ RSpec.describe Committer::CommitGenerator do
       let(:scopes) { %w[api ui docs] }
 
       before do
-        allow(Committer::Config).to receive(:load).and_return(scopes: scopes)
+        config_instance = instance_double(Committer::Config)
+        allow(config_instance).to receive(:[]).with('scopes').and_return(scopes)
+        allow(Committer::Config).to receive(:instance).and_return(config_instance)
       end
 
       it 'builds prompt with scopes' do
@@ -52,7 +56,9 @@ RSpec.describe Committer::CommitGenerator do
       let(:generator) { described_class.new(diff, commit_context) }
 
       before do
-        allow(Committer::Config).to receive(:load).and_return({})
+        config_instance = instance_double(Committer::Config)
+        allow(config_instance).to receive(:[]).with('scopes').and_return(nil)
+        allow(Committer::Config).to receive(:instance).and_return(config_instance)
       end
 
       it 'uses the template with body' do

--- a/spec/committer/commit_generator_spec.rb
+++ b/spec/committer/commit_generator_spec.rb
@@ -10,19 +10,25 @@ RSpec.describe Committer::CommitGenerator do
   let(:body_response) { JSON.parse(load_fixture('claude_response_with_body.json')) }
   let(:client_instance) { instance_double(Clients::ClaudeClient) }
   let(:generator) { described_class.new(diff, commit_context) }
+  let(:temp_home) { Dir.mktmpdir }
+  let(:config_dir) { File.join(temp_home, '.committer') }
+  let(:config_file) { File.join(config_dir, 'config.yml') }
 
   before do
-    allow(Clients::ClaudeClient).to receive(:new).and_return(client_instance)
+    stub_const('Committer::Config::CONFIG_DIR', config_dir)
+    stub_const('Committer::Config::CONFIG_FILE', config_file)
+    allow(Dir).to receive(:home).and_return(temp_home)
+    FileUtils.mkdir_p(config_dir)
+    File.write(config_file, { api_key: 'dummyKey', scopes: [] }.to_yaml)
+    Committer::Config.instance.reload
+  end
+
+  after do
+    FileUtils.remove_entry(temp_home) if File.directory?(temp_home)
   end
 
   describe '#build_commit_prompt' do
     context 'when no scopes are configured' do
-      before do
-        config_instance = instance_double(Committer::Config)
-        allow(config_instance).to receive(:[]).with('scopes').and_return(nil)
-        allow(Committer::Config).to receive(:instance).and_return(config_instance)
-      end
-
       it 'builds prompt with no scopes' do
         prompt = generator.build_commit_prompt
         expect(prompt).to include('DO NOT include a scope in your commit message')
@@ -35,9 +41,9 @@ RSpec.describe Committer::CommitGenerator do
       let(:scopes) { %w[api ui docs] }
 
       before do
-        config_instance = instance_double(Committer::Config)
-        allow(config_instance).to receive(:[]).with('scopes').and_return(scopes)
-        allow(Committer::Config).to receive(:instance).and_return(config_instance)
+        FileUtils.mkdir_p(config_dir)
+        File.write(config_file, { api_key: 'dummyKey', scopes: %w[api ui docs] }.to_yaml)
+        Committer::Config.instance.reload
       end
 
       it 'builds prompt with scopes' do
@@ -55,12 +61,6 @@ RSpec.describe Committer::CommitGenerator do
       let(:commit_context) { 'This is a version bump for the next release' }
       let(:generator) { described_class.new(diff, commit_context) }
 
-      before do
-        config_instance = instance_double(Committer::Config)
-        allow(config_instance).to receive(:[]).with('scopes').and_return(nil)
-        allow(Committer::Config).to receive(:instance).and_return(config_instance)
-      end
-
       it 'uses the template with body' do
         expect(generator).to receive(:template).and_call_original
         prompt = generator.build_commit_prompt
@@ -72,10 +72,6 @@ RSpec.describe Committer::CommitGenerator do
     context 'when no commit context is provided' do
       let(:commit_context) { nil }
       let(:generator) { described_class.new(diff, commit_context) }
-
-      before do
-        allow(Committer::Config).to receive(:load).and_return({})
-      end
 
       it 'uses summary-only template when commit context is nil' do
         expect(generator).to receive(:template).and_call_original
@@ -129,51 +125,14 @@ RSpec.describe Committer::CommitGenerator do
     end
   end
 
-  describe '#parse_response' do
-    context 'when commit context is nil or empty' do
-      it 'returns only summary when context is nil' do
-        result = generator.parse_response(summary_response)
-        expect(result[:summary]).to eq('chore: bump version from 0.1.0 to 0.1.1')
-        expect(result[:body]).to be_nil
-      end
-
-      it 'returns only summary when context is empty' do
-        generator = described_class.new(diff, '')
-        result = generator.parse_response(summary_response)
-        expect(result[:summary]).to eq('chore: bump version from 0.1.0 to 0.1.1')
-        expect(result[:body]).to be_nil
-      end
-    end
-
-    context 'when commit context is provided' do
-      let(:commit_context) { 'Some context for the commit' }
-      let(:generator) { described_class.new(diff, commit_context) }
-
-      it 'returns summary and body' do
-        result = generator.parse_response(body_response)
-        expect(result[:summary]).to eq('chore: bump version from 0.1.0 to 0.1.1')
-        expect(result[:body]).to include('Incremented patch version')
-        # Verify body was wrapped at 80 characters
-        body_lines = result[:body].split("\n")
-        body_lines.each do |line|
-          expect(line.length).to be <= 80
-        end
-      end
-    end
-  end
-
   describe '#prepare_commit_message' do
     context 'when called with diff and no context' do
       before do
-        allow(client_instance).to receive(:post).and_return(summary_response)
-        allow(generator).to receive(:puts)
+        stub_request(:post, 'https://api.anthropic.com/v1/messages')
+          .to_return(status: 200, body: summary_response.to_json, headers: { 'Content-Type' => 'application/json' })
       end
 
       it 'builds prompt, calls API and parses response' do
-        expect(generator).to receive(:build_commit_prompt).and_call_original
-        expect(client_instance).to receive(:post)
-        expect(generator).to receive(:parse_response).with(summary_response).and_call_original
-
         result = generator.prepare_commit_message
         expect(result[:summary]).to eq('chore: bump version from 0.1.0 to 0.1.1')
         expect(result[:body]).to be_nil
@@ -185,15 +144,11 @@ RSpec.describe Committer::CommitGenerator do
       let(:generator) { described_class.new(diff, commit_context) }
 
       before do
-        allow(client_instance).to receive(:post).and_return(body_response)
-        allow(generator).to receive(:puts)
+        stub_request(:post, 'https://api.anthropic.com/v1/messages')
+          .to_return(status: 200, body: body_response.to_json, headers: { 'Content-Type' => 'application/json' })
       end
 
       it 'builds prompt with context, calls API and parses response' do
-        expect(generator).to receive(:build_commit_prompt).and_call_original
-        expect(client_instance).to receive(:post)
-        expect(generator).to receive(:parse_response).with(body_response).and_call_original
-
         result = generator.prepare_commit_message
         expect(result[:summary]).to eq('chore: bump version from 0.1.0 to 0.1.1')
         expect(result[:body]).to include('Incremented patch version')


### PR DESCRIPTION
Support per repo config, so it works seamless across teams if it doesnt exist falls back to global config.

refactored config to be a singleton to reduce file loads

refactored test to be less fragile