### PR TITLE
refactor: replace HTTParty with standard Ruby Net::HTTP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    csv (3.3.0)
+    csv (3.3.2)
     diff-lcs (1.6.0)
     hashdiff (1.1.2)
     httparty (0.22.0)

--- a/committer.gemspec
+++ b/committer.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |spec|
   spec.executables = %w[committer]
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'httparty', '~> 0.20'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Remove HTTParty dependency and refactor Claude client to use Ruby's standard Net::HTTP library. This change reduces external dependencies which were causing errors on some systems while maintaining the same functionality. The HTTP request handling is now implemented using built-in Ruby libraries, making the application more stable across different environments and reducing the dependency surface area.