### PR TITLE
feat: Added ability to use other clients in the future

### DIFF
--- a/lib/committer/commit_generator.rb
+++ b/lib/committer/commit_generator.rb
@@ -70,8 +70,8 @@ module Committer
       end
     end
 
-    def prepare_commit_message
-      client = Clients::ClaudeClient.new
+    def prepare_commit_message(client_class = Clients::ClaudeClient)
+      client = client_class.new
 
       prompt = build_commit_prompt
       response = client.post(prompt)

--- a/spec/committer/commit_generator_spec.rb
+++ b/spec/committer/commit_generator_spec.rb
@@ -202,22 +202,18 @@ RSpec.describe Committer::CommitGenerator do
     end
 
     context 'when called with a different client' do
-      class Clients::SomeOtherClient
-        def post(_prompt); end
-      end
-
-      let(:client_instance) { instance_double(Clients::SomeOtherClient) }
+      let(:client_class) { class_double('Clients::SomeOtherClient', new: client_instance).as_stubbed_const }
+      let(:client_instance) { instance_double('Clients::SomeOtherClient', post: nil) }
       let(:generator) { described_class.new(diff, commit_context) }
 
       before do
-        allow(Clients::SomeOtherClient).to receive(:new).and_return(client_instance)
         allow(generator).to receive(:build_commit_prompt).and_return('my prompt')
         allow(generator).to receive(:parse_response)
         allow(client_instance).to receive(:post)
       end
 
       it 'builds the prompt and passes it to the client' do
-        generator.prepare_commit_message(Clients::SomeOtherClient)
+        generator.prepare_commit_message(client_class)
 
         expect(client_instance).to have_received(:post).with('my prompt')
       end

--- a/spec/committer/commit_generator_spec.rb
+++ b/spec/committer/commit_generator_spec.rb
@@ -200,5 +200,27 @@ RSpec.describe Committer::CommitGenerator do
         expect(result[:body]).to include('Incremented patch version')
       end
     end
+
+    context 'when called with a different client' do
+      class Clients::SomeOtherClient
+        def post(_prompt); end
+      end
+
+      let(:client_instance) { instance_double(Clients::SomeOtherClient) }
+      let(:generator) { described_class.new(diff, commit_context) }
+
+      before do
+        allow(Clients::SomeOtherClient).to receive(:new).and_return(client_instance)
+        allow(generator).to receive(:build_commit_prompt).and_return('my prompt')
+        allow(generator).to receive(:parse_response)
+        allow(client_instance).to receive(:post)
+      end
+
+      it 'builds the prompt and passes it to the client' do
+        generator.prepare_commit_message(Clients::SomeOtherClient)
+
+        expect(client_instance).to have_received(:post).with('my prompt')
+      end
+    end
   end
 end


### PR DESCRIPTION
I've added dep injection so in the future, other clients can be added 👍 

Not sure if the tests are robust enough but I imagine if there is a different client, there would be client specific integration tests to cover it? 

