### PR TITLE
refactor: implement separate prompt templates for commit messages

### DIFF
--- a/lib/committer/commit_generator.rb
+++ b/lib/committer/commit_generator.rb
@@ -16,9 +16,8 @@ module Committer
     end
 
     def build_commit_prompt
-      format(template,
-             diff: @diff,
-             commit_context: @commit_context)
+      scopes = Committer::Config::Accessor.instance[:scopes] || []
+      Committer::PromptTemplates.build_prompt(diff, scopes, commit_context)
     end
 
     def template

--- a/lib/committer/config/accessor.rb
+++ b/lib/committer/config/accessor.rb
@@ -52,10 +52,6 @@ module Committer
         File.read(path)
       end
 
-      def load_formatting_rules
-        read_path_prioritized_file(Committer::Config::Constants::FORMATTING_RULES_FILE_NAME)
-      end
-
       def read_file_from_git_root(file_name)
         read_file_from_path(File.join(Committer::GitHelper.repo_root, '.committer', file_name))
       end

--- a/lib/committer/config/constants.rb
+++ b/lib/committer/config/constants.rb
@@ -6,7 +6,8 @@ module Committer
       CONFIG_DIR = File.join(Dir.home, '.committer')
       DEFAULTS_PATH = File.join(File.dirname(__FILE__), './defaults')
 
-      FORMATTING_RULES_FILE_NAME = 'formatting_rules.txt'
+      COMMIT_MESSAGE_ONLY_PROMPT_FILE_NAME = 'commit_message_only.prompt'
+      COMMIT_MESSAGE_AND_BODY_PROMPT_FILE_NAME = 'commit_message_and_body.prompt'
       CONFIG_FILE_NAME = 'config.yml'
 
       DEFAULT_CONFIG = {

--- a/lib/committer/config/defaults/commit_message_and_body.prompt
+++ b/lib/committer/config/defaults/commit_message_and_body.prompt
@@ -1,0 +1,52 @@
+You are an experienced software developer tasked with creating a commit message based on a git diff. Your goal is to produce a clear, concise, and informative commit message.
+
+First, carefully analyze the following git diff:
+
+<git_diff>
+{{DIFF}}
+</git_diff>
+
+Here are the available scopes (if any):
+
+<scopes>
+{{SCOPES}}
+</scopes>
+
+<user_context>
+{{CONTEXT}}
+</user_context>
+
+Please follow these instructions to generate the commit message:
+
+1. Analyze the git diff and determine the most appropriate commit type from the following options:
+   - feat: A new feature
+   - fix: A bug fix
+   - docs: Documentation only changes
+   - style: Changes that do not affect the meaning of the code
+   - refactor: A code change that neither fixes a bug nor adds a feature
+   - perf: A code change that improves performance
+   - test: Adding missing tests or correcting existing tests
+   - chore: Changes to the build process or auxiliary tools and libraries
+
+
+2. Adhere to these message guidelines:
+   - Keep the summary under 70 characters
+   - Use imperative, present tense (e.g., "add" not "added" or "adds")
+   - Do not end the summary with a period
+   - Be concise but descriptive
+
+3. Format the commit message as follows:
+   - If a scope is available: <type>(<scope>): <description>
+   - If no scope is available: <type>: <description>
+
+4 Body Guidelines:
+   - Add a blank line between summary and body
+   - Use the body to explain why the change was made, incorporating the user's context, defined in <user_context>
+   - Wrap each line in the body at 80 characters maximum
+   - Break the body into multiple paragraphs if needed
+
+   [Your concise commit message in the specified format]
+   [blank line]
+   [Your detailed commit message body]
+
+Respond ONLY with the commit message text (message and body), nothing else.

--- a/lib/committer/config/defaults/commit_message_only.prompt
+++ b/lib/committer/config/defaults/commit_message_only.prompt
@@ -1,0 +1,38 @@
+You are an experienced software developer tasked with creating a commit message based on a git diff. Your goal is to produce a clear, concise, and informative commit message.
+
+First, carefully analyze the following git diff:
+
+<git_diff>
+{{DIFF}}
+</git_diff>
+
+Here are the available scopes (if any):
+
+<scopes>
+{{SCOPES}}
+</scopes>
+
+Please follow these instructions to generate the commit message:
+
+1. Analyze the git diff and determine the most appropriate commit type from the following options:
+   - feat: A new feature
+   - fix: A bug fix
+   - docs: Documentation only changes
+   - style: Changes that do not affect the meaning of the code
+   - refactor: A code change that neither fixes a bug nor adds a feature
+   - perf: A code change that improves performance
+   - test: Adding missing tests or correcting existing tests
+   - chore: Changes to the build process or auxiliary tools and libraries
+
+
+2. Adhere to these message guidelines:
+   - Keep the summary under 70 characters
+   - Use imperative, present tense (e.g., "add" not "added" or "adds")
+   - Do not end the summary with a period
+   - Be concise but descriptive
+
+3. Format the commit message as follows:
+   - If a scope is available: <type>(<scope>): <description>
+   - If no scope is available: <type>: <description>
+
+Respond ONLY with the commit message line, nothing else.

--- a/lib/committer/config/writer.rb
+++ b/lib/committer/config/writer.rb
@@ -20,7 +20,6 @@ module Committer
 
       def setup
         create_default_config
-        create_sample_formatting_rules
       end
 
       def write_config_file(file_path, contents)
@@ -32,15 +31,6 @@ module Committer
           File.write(file_path, contents)
           true
         end
-      end
-
-      def create_sample_formatting_rules
-        default_formatting_rules = File.read(File.join(Committer::Config::Constants::DEFAULTS_PATH,
-                                                       Committer::Config::Constants::FORMATTING_RULES_FILE_NAME))
-        formatting_rules_file = File.join(@config_dir,
-                                          "#{Committer::Config::Constants::FORMATTING_RULES_FILE_NAME}.sample")
-        wrote_file = write_config_file(formatting_rules_file, default_formatting_rules)
-        nil unless wrote_file
       end
 
       def create_default_config

--- a/spec/committer/commit_generator_spec.rb
+++ b/spec/committer/commit_generator_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe Committer::CommitGenerator do
       let(:generator) { described_class.new(diff, commit_context) }
 
       it 'uses the template with body' do
-        expect(generator).to receive(:template).and_call_original
         prompt = generator.build_commit_prompt
         expect(prompt).to include(commit_context)
         expect(prompt).to include('Respond ONLY with the commit message text (message and body), nothing else.')
@@ -74,7 +73,6 @@ RSpec.describe Committer::CommitGenerator do
       let(:generator) { described_class.new(diff, commit_context) }
 
       it 'uses summary-only template when commit context is nil' do
-        expect(generator).to receive(:template).and_call_original
         prompt = generator.build_commit_prompt
         expect(prompt).to include('Respond ONLY with the commit message line, nothing else.')
       end

--- a/spec/committer/config/writer_spec.rb
+++ b/spec/committer/config/writer_spec.rb
@@ -43,14 +43,6 @@ RSpec.describe Committer::Config::Writer do
       config = YAML.load_file(config_file)
       expect(config).to eq(Committer::Config::Constants::DEFAULT_CONFIG)
     end
-
-    it 'writes config sample config rules' do
-      expect(File.exist?(sample_formatting_rules_file)).to be false
-      writer.setup
-      expect(File.exist?(sample_formatting_rules_file)).to be true
-      contents = File.read(sample_formatting_rules_file)
-      expect(contents).to include('# Formatting rules for message')
-    end
   end
 
   describe '#create_default_config' do


### PR DESCRIPTION
This change replaces the single formatting rules file with two separate prompt templates - one for commit messages with only a summary and another for messages with both summary and body. The refactoring addresses the challenge of creating a single template that works well for both scenarios, which was difficult to maintain and required powerful models to parse correctly. The implementation adds default prompt files and updates the code to select the appropriate template based on whether a commit context is provided. This gives users the flexibility to customize either format independently while maintaining consistent behavior.