### PR TITLE
feat: improve the prompt based on last evaluation run

### DIFF
--- a/lib/committer/config/defaults/commit_message_only.prompt
+++ b/lib/committer/config/defaults/commit_message_only.prompt
@@ -12,17 +12,6 @@ Here are the available scopes (if any):
 {{SCOPES}}
 </scopes>
 
-Please follow these instructions to generate the commit message:
-
-1. Analyze the git diff and determine the most appropriate commit type from the following options:
-   - feat: A new feature
-   - fix: A bug fix
-   - docs: Documentation only changes
-   - style: Changes that do not affect the meaning of the code
-   - refactor: A code change that neither fixes a bug nor adds a feature
-   - perf: A code change that improves performance
-   - test: Adding missing tests or correcting existing tests
-   - chore: Changes to the build process or auxiliary tools and libraries
 
 
 2. Adhere to these message guidelines:
@@ -34,5 +23,27 @@ Please follow these instructions to generate the commit message:
 3. Format the commit message as follows:
    - If a scope is available: <type>(<scope>): <description>
    - If no scope is available: <type>: <description>
+
+
+Please follow these instructions to generate the commit message:
+
+if such and such changes its docs b ut if commit also has such then its a feat
+
+1. Analyze the git diff and determine the most appropriate commit type from the following options:
+   - feat: A new feature these changes ARE NOT in the docs directory
+   - fix: A bug fix these changes ARE NOT in the docs directory
+   - docs: Documentation only changes for example changes that happen in docs directory
+   - style: Changes that do not affect the code execution (e.g., white-space, formatting, missing semi-colons, etc.) usually done by linters
+   - refactor: 
+      - A code change that does not change the behaviour of the code at all, just how the code is written executed, 
+      - modifing error messages is not a refactor
+      - if parts of the code is removed and no alternative in place IT IS NOT A REFACTOR
+   - perf: A code change that improves performance
+   - test: Adding missing tests or correcting existing tests
+   - build: Changes that affect the build system or external dependencies
+   - ci: 
+      - Changes to the CI configuration files and scripts
+      - these changes should not change the way that the code is built otherwise its build
+
 
 Respond ONLY with the commit message line, nothing else.


### PR DESCRIPTION
basically did some work with evaluator and updated the prompt accordingly

Dropped chore as the term is too overloaded and is not part of the [electron](https://www.electronjs.org/docs/latest/development/pull-requests#step-5-commit) or [anglular](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md) specs